### PR TITLE
Add integration tests to ensure artifacts are signed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,26 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <version>3.0.1</version>
+                <configuration>
+                    <cloneProjectsTo>${project.build.directory}/it/projects</cloneProjectsTo>
+                    <localRepositoryPath>${project.build.directory}/it/repository</localRepositoryPath>
+                    <invokerPropertiesFile>invoker.properties</invokerPropertiesFile>
+                    <postBuildHookScript>assertions.bsh</postBuildHookScript>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <goals>
+                            <goal>install</goal>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${version.jacoco.plugin}</version>

--- a/src/it/sign-artifacts/assertions.bsh
+++ b/src/it/sign-artifacts/assertions.bsh
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Decipher Technology Studios LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.*;
+
+File artifactDir = new File(localRepositoryPath, "com/deciphernow/bouncycastle-maven-plugin-sign-artifacts-it/1.0.0");
+
+String[] ascFiles = {
+        "bouncycastle-maven-plugin-sign-artifacts-it-1.0.0.pom.asc",
+        "bouncycastle-maven-plugin-sign-artifacts-it-1.0.0.jar.asc",
+        "bouncycastle-maven-plugin-sign-artifacts-it-1.0.0-sources.jar.asc",
+};
+
+for (String ascFile : ascFiles) {
+    File file = new File(artifactDir, ascFile);
+    if (!file.isFile()) {
+        throw new Exception("Missing file " + file);
+    } else {
+        System.out.println(ascFile + " has been generated");
+    }
+}
+

--- a/src/it/sign-artifacts/invoker.properties
+++ b/src/it/sign-artifacts/invoker.properties
@@ -1,0 +1,15 @@
+#
+# Copyright 2017 Decipher Technology Studios LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+invoker.goals=clean install

--- a/src/it/sign-artifacts/pom.xml
+++ b/src/it/sign-artifacts/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2017 Decipher Technology Studios LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.deciphernow</groupId>
+    <artifactId>bouncycastle-maven-plugin-sign-artifacts-it</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <description>Check if project and attached artifacts are signed and installed</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.gmaven</groupId>
+                <artifactId>groovy-maven-plugin</artifactId>
+                <version>2.0</version>
+                <executions>
+                    <execution>
+                        <id>create-ring-property-with-private-key-content</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>execute</goal>
+                        </goals>
+                        <configuration>
+                            <properties>
+                                <keysFile>
+                                    @project.basedir@/src/test/resources/com/deciphernow/maven/plugins/bouncycastle/keys.asc
+                                </keysFile>
+                            </properties>
+                            <source>
+                                def privateKey = new File(properties['keysFile']).getText()
+                                project.properties.rings = privateKey
+                            </source>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.deciphernow</groupId>
+                <artifactId>bouncycastle-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <passphrase>latrommI</passphrase>
+                    <rings>${rings}</rings>
+                    <userId>immortal@deciphernow.com</userId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <configuration>
+                    <forceCreation>true</forceCreation>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
This pull request uses the `maven-invoker-plugin` to validate `SignMojo` behavior by running new integration tests in `src/it` folder. This plugin do the following:

- Execute `mvn clean install` for test project `src/it/sign-artifacts/pom.xml`
- Execute `assertions.bsh` to check if asc files have been generated

Note that `src/it/sign-artifacts/pom.xml` uses `groovy-maven-plugin` to cat the content of `keys.asc` into a maven variable. 

This could also be reused for https://github.com/DecipherNow/bouncycastle-maven-plugin/issues/10