### PR TITLE
Resolving issue with attached artifact with classifier not being signed

### DIFF
--- a/src/it/sign-attached-artifact/assertions.bsh
+++ b/src/it/sign-attached-artifact/assertions.bsh
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Decipher Technology Studios LLC & Dominik Cebula <dominikcebula@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.File;
+
+File ascFile = new File(localRepositoryPath, "it/sign-attached-artifact/1.0.0/sign-attached-artifact-1.0.0-obfuscated.jar.asc");
+if (!ascFile.isFile()) {
+    throw new Exception("Missing file signature for attached artifact, expected signature in: " + ascFile);
+}

--- a/src/it/sign-attached-artifact/invoker.properties
+++ b/src/it/sign-attached-artifact/invoker.properties
@@ -1,0 +1,15 @@
+#
+# Copyright 2020 Decipher Technology Studios LLC & Dominik Cebula <dominikcebula@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+invoker.goals=clean install

--- a/src/it/sign-attached-artifact/pom.xml
+++ b/src/it/sign-attached-artifact/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Copyright 2020 Decipher Technology Studios LLC & Dominik Cebula <dominikcebula@gmail.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>it</groupId>
+        <artifactId>common</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>sign-attached-artifact</artifactId>
+    <packaging>jar</packaging>
+    <description>Check if attached artifacts can be signed with a keyring read from a file</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.wvengen</groupId>
+                <artifactId>proguard-maven-plugin</artifactId>
+                <version>2.2.0</version>
+                <executions>
+                    <execution>
+                        <id>package-obfuscated-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>proguard</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <obfuscate>true</obfuscate>
+                    <options>
+                        <option>-keep public class * { *; }</option>
+                    </options>
+                    <injar>${project.build.finalName}.jar</injar>
+                    <outjar>${project.build.finalName}-obfuscated.jar</outjar>
+                    <libs>
+                        <lib>${java.home}/lib/rt.jar</lib>
+                    </libs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-obfuscated-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${project.basedir}/target/${project.build.finalName}-obfuscated.jar</file>
+                                    <type>jar</type>
+                                    <classifier>obfuscated</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.deciphernow</groupId>
+                <artifactId>bouncycastle-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <passphrase>latrommI</passphrase>
+                    <secretKeyring>
+                        @project.build.testOutputDirectory@/com/deciphernow/maven/plugins/bouncycastle/keys.asc
+                    </secretKeyring>
+                    <userId>immortal@deciphernow.com</userId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/it/sign-attached-artifact/src/main/java/it/sign/attached/artifact/TestClass.java
+++ b/src/it/sign-attached-artifact/src/main/java/it/sign/attached/artifact/TestClass.java
@@ -1,0 +1,5 @@
+package it.sign.attached.artifact;
+
+public class TestClass {
+
+}

--- a/src/main/java/com/deciphernow/maven/plugins/bouncycastle/SignMojo.java
+++ b/src/main/java/com/deciphernow/maven/plugins/bouncycastle/SignMojo.java
@@ -150,10 +150,9 @@ public class SignMojo extends AbstractMojo {
     for (Object object : this.project.getAttachedArtifacts()) {
       Artifact artifact = (Artifact) object;
       File signatureFile = signArtifact(artifact, key);
-      ArtifactHandler artifactHandler = artifact.getArtifactHandler();
       signedArtifacts.add(new SignedArtifact(
-              String.format("%s.asc", artifactHandler.getExtension()),
-              artifactHandler.getClassifier(),
+              String.format("%s.asc", artifact.getArtifactHandler().getExtension()),
+              artifact.getClassifier(),
               signatureFile));
     }
     return signedArtifacts;


### PR DESCRIPTION
Joshua, version 1.1.0 that was released yesterday and was discussed via e-mail works great, except for an issue that I have just find out with attached artifacts with classifiers.

Problem is that when plugin is used with build-helper-maven-plugin and attach-artifact goal, artifacts with classifiers are not being signed.

To show the issue I have implemented Integration Test sign-attached-artifact under commit 3d63c73, running it from this commit shows the issue:
![image](https://user-images.githubusercontent.com/18147736/80108948-3718cd80-857d-11ea-8e2f-3a1b7bd154c5.png)

Within 631060d I have implemented proposition of the fix, running Integration Test sign-attached-artifact after this commit, makes test green:
![image](https://user-images.githubusercontent.com/18147736/80109084-5e6f9a80-857d-11ea-8575-d708b2e5de8e.png)

Could you please have a look at those changes, approve pull request and release version 1.1.1 if fix is correct?